### PR TITLE
Add OpenGL device (dri)

### DIFF
--- a/io.github.foldynl.QLog.yaml
+++ b/io.github.foldynl.QLog.yaml
@@ -9,6 +9,7 @@ rename-desktop-file: qlog.desktop
 rename-icon: qlog
 finish-args:
   - --device=all
+  - --device=dri
   - --share=network
   - --share=ipc
   - --socket=pulseaudio


### PR DESCRIPTION
Sometimes QT dialogs are rendered with a black border. Adding device=dri fixes this issue.