### PR TITLE
qlog: Migration to QT6.8 runtime

### DIFF
--- a/io.github.foldynl.QLog.yaml
+++ b/io.github.foldynl.QLog.yaml
@@ -1,9 +1,9 @@
 app-id: io.github.foldynl.QLog
 runtime: org.kde.Platform
-runtime-version: 5.15-23.08
+runtime-version: "6.8"
 sdk: org.kde.Sdk
 base: io.qt.qtwebengine.BaseApp
-base-version: 5.15-23.08
+base-version: "6.8"
 command: qlog
 rename-desktop-file: qlog.desktop
 rename-icon: qlog
@@ -62,6 +62,8 @@ modules:
           type: anitya
           project-id: 4138
           url-template: https://github.com/frankosterfeld/qtkeychain/archive/refs/tags/$version.tar.gz
+    config-opts:
+    - -DBUILD_WITH_QT6=ON
 
   - name: wxwidgets
     buildsystem: cmake-ninja
@@ -119,7 +121,7 @@ modules:
     buildsystem: qmake
     build-options:
       env:
-        - QMAKEPATH=/app/lib
+        - QMAKEPATH=/app/
     config-opts:
       - QMAKE_LIBS += -L/app/lib
       - QMAKE_INCDIR+=/app/include/QtWebEngine


### PR DESCRIPTION
Please do not merge it now. 

A new release of QLog 0.41 will be released in the coming days, which will add fixes for QT6.8. Then it is possible to use the PR #42  that migrates hamlib 4.6 and this PR to release the new QLog release 0.41.