### PR TITLE
qlog: Migration to QT6.10 runtime

### DIFF
--- a/io.github.foldynl.QLog.yaml
+++ b/io.github.foldynl.QLog.yaml
@@ -1,9 +1,9 @@
 app-id: io.github.foldynl.QLog
 runtime: org.kde.Platform
-runtime-version: '6.9'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 base: io.qt.qtwebengine.BaseApp
-base-version: '6.9'
+base-version: '6.10'
 command: qlog
 rename-desktop-file: qlog.desktop
 rename-icon: qlog


### PR DESCRIPTION
upgrade to QT6.10 runtime. No further changes needed, QLog should be ready